### PR TITLE
x1 in trades fixed.

### DIFF
--- a/trade.lua
+++ b/trade.lua
@@ -5,7 +5,8 @@ function GogoLoot:GetItemLink(data)
     local link = data[7]--"[" .. data[1] .. "]" -- item links are broken on ptr. Use data[7] if its fixed
 
 
-    return link .. "x" .. tostring(quan)
+    if quan == 1 then return link else return string.format("$s x$d", link, quan) end
+    --return link .. "x" .. tostring(quan)
 end
 
 function GogoLoot:GetGoldString(value)


### PR DESCRIPTION
- Removed 'x1' from trade when quantity is only 1.
- Added a space for all other quantities.